### PR TITLE
Added some comment based help for displaying with "Get-Help <powershell script>"

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,26 +18,36 @@ Generate a Gmail filter from a list of domains
 
 #### [genfilter.ps1](genfilter.ps1):
 ```
-PS /> Get-Help ./genfilter.ps1
+PS> get-help .\genfilter.ps1
 
 NAME
     ./genfilter.ps1
 
 SYNOPSIS
+    Generate a mail filters file for blocking Evil Recruiter Spam
 
 
 SYNTAX
-    ./genfilter.ps1 [[-list] <String>] [[-format] <String>] [[-outfile] <String>]
-    [<CommonParameters>]
+    ./genfilter.ps1 [[-list] <String>] [[-format] <String>] [[-outfile] <String>] [<CommonParameters>]
 
 
 DESCRIPTION
+    This PowerShell script will generate either Gmail style mail filters (in XML format)
+    or CSV style mail filters (perfect for ZOHO and perhaps other mail providers)
+
+    By default, the "list.txt" file will be consumed and a mailFilters.xml file will
+    be generated. This is ideal for Gmail filter imports. You can optionally provide
+    a different file name or path, a file format (currently "csv" or "default" which is XML),
+    and and output file path/name. The default output file is mailFilter.<file extension here>,
+    such as mailFilter.xml or mailFilters.csv
 
 
 RELATED LINKS
+    The GitHub repo for this script can found here: https://github.com/jceloria/recruiter-spam
 
 REMARKS
-    To see the examples, type: "Get-Help ./genfilter.ps1 -Examples"
-    For more information, type: "Get-Help ./genfilter.ps1 -Detailed"
-    For technical information, type: "Get-Help ./genfilter.ps1 -Full"
+    To see the examples, type: "get-help F:\Code\recruiter-spam\genfilter.ps1 -examples".
+    For more information, type: "get-help F:\Code\recruiter-spam\genfilter.ps1 -detailed".
+    For technical information, type: "get-help F:\Code\recruiter-spam\genfilter.ps1 -full".
+    For online help, type: "get-help F:\Code\recruiter-spam\genfilter.ps1 -online"
 ```

--- a/genfilter.ps1
+++ b/genfilter.ps1
@@ -1,4 +1,54 @@
-<# .SYNOPSIS #>
+# Docs on how to add to the Get-Help menu:
+# https://docs.microsoft.com/en-us/powershell/scripting/developer/help/examples-of-comment-based-help?view=powershell-7.1
+
+<#
+		.SYNOPSIS
+		Generate a mail filters file for blocking Evil Recruiter Spam
+
+		.Description
+		This PowerShell script will generate either Gmail style mail filters (in XML format)
+		or CSV style mail filters (perfect for ZOHO and perhaps other mail providers)
+		
+		By default, the "list.txt" file will be consumed and a mailFilters.xml file will
+		be generated. This is ideal for Gmail filter imports. You can optionally provide
+		a different file name or path, a file format (currently "csv" or "default" which is XML),
+		and and output file path/name. The default output file is mailFilter.<file extension here>,
+		such as mailFilter.xml or mailFilters.csv
+		
+		.INPUTS
+		Text file containing a list of emails to mark as spam. This file should be newline separated.
+		
+		.OUTPUTS
+		Either an XML file (default option) or a CSV file with the list of emails formatted for importing into Gmail or other inbox systems and marking them as spam.
+		
+		.PARAMETER list
+		Specifices the email list of spammers for this script to consume
+		
+		.PARAMETER format
+		Specifices the file format to generate; currently 'default' is XML, 'csv' is CSV
+		
+		.PARAMETER outfile
+		Specifics the output file path/name. By default the file is named ".\mailFilters.$format"
+		
+		.EXAMPLE
+		PS> .\genfilter.ps1
+		-> default options used of 'list.txt', 'xml' and 'mailFilter.xml'
+		
+		.EXAMPLE
+		PS> .\genfilter.ps1 "list.txt" "xml" "mailFilters2.xml"
+		-> default file input / export file format, but the output file is called "mailFilters2.xml"
+		
+		.EXAMPLE
+		PS> .\genfilter.ps1 "list.txt" "csv" "mailFilters.csv"
+		-> generates a CSV file called mailFilters.csv in the same directory
+		
+		.LINK
+		The GitHub repo for this script can found here: https://github.com/jceloria/recruiter-spam
+		
+		.NOTES
+		Created by John Celoria; this help added by Jason Downing
+#> 
+
 param (
     [string] $list = ".\list.txt",
     [string] $format = "xml",


### PR DESCRIPTION
Implements #3. I followed this Microsoft Docs example: 

https://docs.microsoft.com/en-us/powershell/scripting/developer/help/examples-of-comment-based-help?view=powershell-7.1

Example of what appears:

**Default help options**
![image](https://user-images.githubusercontent.com/7584563/132899518-1d726652-4118-4a55-a0a4-435a9cbcde3b.png)

** Passing -full to get-help **
![image](https://user-images.githubusercontent.com/7584563/132899620-c097a5da-48a8-4f48-902a-59df451f9b3c.png)
![image](https://user-images.githubusercontent.com/7584563/132899601-2a99ea04-1695-4bd1-833e-51238a8a29d6.png)
