### PR TITLE
Newest spammers 9/16/2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,24 @@ RELATED LINKS
     The GitHub repo for this script can found here: https://github.com/jceloria/recruiter-spam
 
 REMARKS
-    To see the examples, type: "get-help F:\Code\recruiter-spam\genfilter.ps1 -examples".
-    For more information, type: "get-help F:\Code\recruiter-spam\genfilter.ps1 -detailed".
-    For technical information, type: "get-help F:\Code\recruiter-spam\genfilter.ps1 -full".
-    For online help, type: "get-help F:\Code\recruiter-spam\genfilter.ps1 -online"
+    To see the examples, type: "get-help genfilter.ps1 -examples".
+    For more information, type: "get-help genfilter.ps1 -detailed".
+    For technical information, type: "get-help genfilter.ps1 -full".
+    For online help, type: "get-help "genfilter.ps1 -online"
+```
+
+### Examples for the PowerShell script:
+```
+PS>.\genfilter.ps1
+
+    -> default options used of 'list.txt', 'xml' and 'mailFilter.xml'
+		
+PS>.\genfilter.ps1 "list.txt" "xml" "mailFilters2.xml"
+
+    -> default file input / export file format, but the output file is called "mailFilters2.xml"
+		
+PS>.\genfilter.ps1 "list.txt" "csv" "mailFilters.csv"
+
+    -> generates a CSV file called mailFilters.csv in the same directory
+
 ```

--- a/compareLists.ps1
+++ b/compareLists.ps1
@@ -1,0 +1,69 @@
+<#
+		.SYNOPSIS
+		Compares a mail filters file against an exported filters filter
+
+		.Description
+		This PowerShell script will compare two CSV files and generate a new one with
+		just the differences. This can be helpful for updating a ZOHO blocked domain list.
+		
+		.INPUTS
+		Two CSV files. The first should be the "mailFilters.csv" file. The second should be a comparsion file, like "Blocked_Domains.csv"
+		
+		.OUTPUTS
+		A CSV file with the list of emails formatted for importing into Gmail or other inbox systems and marking them as spam.
+		
+		.PARAMETER mailFilters
+		The current generated mail filters CSV file from the list.txt file in this repo
+		
+		.PARAMETER blockedDomains
+		The exported list of domains from your mail system; ZOHO calls this "Blocked_Domains.csv" by default.
+		
+		.EXAMPLE
+		PS> .\compare_lists.ps1
+		-> default options used of 'mailFilter.csv' and 'Blocked_Domains.csv'
+		
+		.EXAMPLE
+		PS> .\genfilter.ps1 "list.txt" "xml" "mailFilters2.xml"
+		-> default file input / export file format, but the output file is called "mailFilters2.xml"
+		
+		.LINK
+		The GitHub repo for this script can found here: https://github.com/jceloria/recruiter-spam
+		
+		.NOTES
+		Created by Jason Downing, original PowerShell script/lists by John Celoria
+#> 
+
+param (
+    [string] $mailFilters = "mailFilters.csv",
+    [string] $blockedDomains = "Blocked_Domains.csv",
+		[string] $outfile = ".\mailFilters_diffs.csv"
+)
+
+function Generate-CSV {
+    foreach($line in Get-Content $list) {
+        $file += $line + "`n"
+    }
+
+    $file.TrimEnd("\n")
+}
+
+function compareCSV_Files {
+	# https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/compare-object?view=powershell-7.1
+	
+	$file1 = import-csv $mailFilters
+	$file2 = import-csv $blockedDomains
+	
+	$objects = @{
+		ReferenceObject = (Get-Content $mailFilters)
+		DifferenceObject = (Get-Content $blockedDomains)
+	}
+	
+	# This had some helpful tips in the comments, which is how I finally got the file name extracted.
+	# https://stackoverflow.com/questions/36556181/powershell-extract-inputobject-data-from-compare-object-while-comparing-2-csv
+	foreach ($line in Compare-Object @objects) {
+    $line | Select-Object -ExpandProperty InputObject
+	}
+	
+}
+
+compareCSV_Files | Tee-Object -FilePath $outfile

--- a/genfilter.ps1
+++ b/genfilter.ps1
@@ -84,10 +84,10 @@ function Generate-XML {
 
 function Generate-CSV {
     foreach($line in Get-Content $list) {
-        $file += $line + ","
+        $file += $line + "`n"
     }
 
-    $file.TrimEnd(",")
+    $file.TrimEnd("\n")
 }
 
 switch ($format) {

--- a/list.txt
+++ b/list.txt
@@ -194,6 +194,7 @@ tgtus.com
 transcend-staffing.com
 tungaservices.com
 upstreamgs.com
+usgrpinc.com
 ustechsolutions.com
 ustechsolutionsinc.com
 ustsmail.com

--- a/list.txt
+++ b/list.txt
@@ -123,6 +123,7 @@ mamsys.com
 mastech.com
 mastechdigital.com
 mattsonresources.com
+mavenco.com
 maxeleven.com
 mindlance.com
 mindteck.com

--- a/list.txt
+++ b/list.txt
@@ -1,4 +1,5 @@
 4ci-usa.com
+DISYS.COM
 aasolutionsinc.com
 absiusa.com
 acetechnologies.com
@@ -18,6 +19,7 @@ angeliquerecruiting.com
 anviktek.com
 apexnetworks.info
 apolisrises.com
+apolloventuresgroup.com
 artech.com
 artechinfo.com
 ascentsg.com
@@ -130,6 +132,7 @@ motionrecruitment.com
 msici.net
 msrcosmos.com
 new-cruit.com
+niktor.com
 nityo.com
 okayainfo.com
 oorwindigital.com
@@ -203,6 +206,3 @@ w3global.com
 webmsi.com
 xoriant.com
 youcangroe.com
-DISYS.COM
-apolloventuresgroup.com
-niktor.com

--- a/list.txt
+++ b/list.txt
@@ -28,10 +28,12 @@ axelon.com
 axiomglobal.com
 axistalent.io
 axiustek.com
+bayonesolutions.com
 bcforward.com
 beyondsoft.com
 bravotech.com
 briltalenta.com
+buzzclan.com
 bytesys.net
 canbayinc.com
 caspex.com
@@ -42,12 +44,15 @@ codeforce.com
 compnova.com
 compugain.com
 concept-inc.com
+conchtech.com
 consultnet.com
 cssoln.com
 cybercoders.com
+didsolutions.net
 dinanrecruiting.com
 diversant.com
 diverselynx.com
+donatotech.net
 droisys.com
 e-solutionsinc.com
 e.tflux.co
@@ -56,6 +61,7 @@ edgestaffing.com
 edoorsinc.com
 emerge360.com
 emonics.com
+encore-c.com
 enterprisesolutioninc.com
 erostechnologies.com
 eteaminc.com
@@ -78,6 +84,7 @@ holistic-partners.com
 iconstafflabs.com
 idctechno.com
 idctechnologies.com
+iic.com
 imipeople.com
 inabia.com
 infinite-usa.com
@@ -85,6 +92,7 @@ infojiniconsulting.com
 infoorigin.com
 infosoft-inc.com
 infosys.com
+insightglobal.com
 insyncstaffing.jobs
 integratedassociatesinc.com
 intelliprogroup.com
@@ -92,7 +100,6 @@ intelliswift.com
 intellisystechnology.com
 intellyk.com
 intermediagroup.com
-intersect@jobs.net
 intime-info.com
 iplaceusa.com
 iqits.com
@@ -106,6 +113,7 @@ jobspringpartners.com
 judge.com
 kforce.com
 klaxontech.com
+kmmtechnologies.com
 ktekresourcing.com
 lancesoft.com
 logix-tech.net
@@ -113,6 +121,7 @@ mamsys.com
 mastech.com
 mastechdigital.com
 mattsonresources.com
+maxeleven.com
 mindlance.com
 mindteck.com
 minuteman-group.com
@@ -127,8 +136,12 @@ oorwindigital.com
 otsi-usa.com
 palnar.com
 parallelhr.com
+pddninc.net
 pharmalogicsrecruiting.com
+planitgroup.com
+psi-staffing.net
 pyramidci.com
+qsiservicesinc.com
 quantronix.com
 quantumworld.us
 questivity.com
@@ -138,6 +151,7 @@ ramyinfotech.com
 randstadusa.com
 redsalsa.com
 refer.io
+resource-logistics.com
 resource-trac.com
 rht.com
 rjtcompuquest.com
@@ -160,11 +174,14 @@ srimatrix.com
 sunrisesys.com
 suntechnologies.com
 svam.com
+sydatainc.com
 synergisticit.com
 syrinx.com
 systemguru.com
 tanishasystems.com
 teamupstaffing.com
+techstarconsulting.com
+tekleaders.com
 tekshapers.com
 tekstream.com
 tgtus.com
@@ -181,6 +198,11 @@ vedainfo.com
 viatechnical.com
 vicr.com
 vitatechinc.com
+vlinkinfo.com
 w3global.com
+webmsi.com
 xoriant.com
 youcangroe.com
+DISYS.COM
+apolloventuresgroup.com
+niktor.com

--- a/list.txt
+++ b/list.txt
@@ -132,6 +132,7 @@ mondo.com
 motionrecruitment.com
 msici.net
 msrcosmos.com
+mwidminc.com
 new-cruit.com
 niktor.com
 nityo.com
@@ -161,6 +162,7 @@ rht.com
 rjtcompuquest.com
 rpncsystems.com
 rylem.com
+saibber108.com
 sans.com
 saxonglobal.com
 sgsconsulting.com


### PR DESCRIPTION
Also created a script to compare two CSV files. I find this helpful as my email service for my custom domain email (through ZOHO) lets you export email block lists in CSV format. So now I can compare and see if I need to add any new ones that I might have forgotten about.

Also:

* Updated readme - doesn't need to show my file system path in the example help
* Tweaked the CSV generation to match my CSV files - I made it newline based, instead of comma separated. I can add an argument for this instead if you want though.
* Added 26 new spammers. I deleted any full email addresses though - that breaks my email block list import. I was considering doing something like emails.txt and domains.txt to get around this though. Might play around with that, but then that involves a new list to manage. Or I could update the scripts to parse out emails vs domains and generate two lists for my own use.